### PR TITLE
feat: Implement fully functional prayer request system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Resend API Key
+# Get your API key from https://resend.com/api-keys
+RESEND_API_KEY=re_123456789
+
+# Email Configuration
+# The email address that will receive prayer requests
+PRAYER_REQUEST_EMAIL=theservingchurchdallas@gmail.com
+
+# The "from" email address for sending emails
+# This should be a verified domain in Resend (e.g., noreply@yourdomain.com)
+# For testing, you can use onboarding@resend.dev
+RESEND_FROM_EMAIL=noreply@theservingchurch.org

--- a/PRAYER_REQUEST_SETUP.md
+++ b/PRAYER_REQUEST_SETUP.md
@@ -1,0 +1,189 @@
+# Prayer Request Feature Setup
+
+The prayer request page is now fully functional! Here's what was implemented and how to complete the setup.
+
+## What Was Implemented
+
+### 1. Enhanced Prayer Request Form
+- **Location**: `/contact-us/prayer-request`
+- **Features**:
+  - Two tabs: Public Prayer and Private Prayer
+  - Form fields: Name, Email (optional), Prayer Request (textarea)
+  - Professional form styling with proper validation
+  - Loading states and success/error messages
+  - Responsive design with helpful descriptions
+
+### 2. API Endpoint
+- **Location**: `/src/app/api/prayer-requests/route.ts`
+- **Features**:
+  - Handles POST requests from the prayer request form
+  - Validates input data
+  - Sends beautifully formatted HTML and text emails
+  - Differentiates between public and private requests
+  - Includes all submission details with timestamps
+
+### 3. Email Integration
+- **Service**: Resend (https://resend.com)
+- **Features**:
+  - Professional HTML email templates
+  - Color-coded (blue for public, purple for private)
+  - Reply-to support for easy follow-up
+  - Includes all request details
+
+### 4. Bug Fixes
+- Fixed incorrect links in `/contact-us` page
+- Updated contact information to match church details
+
+## Setup Instructions
+
+### Step 1: Get a Resend API Key
+
+1. Go to [https://resend.com](https://resend.com)
+2. Sign up for a free account
+3. Verify your email address
+4. Go to API Keys section
+5. Create a new API key
+6. Copy the API key (it starts with `re_`)
+
+### Step 2: Configure Environment Variables
+
+1. Open `.env.local` in the root of your project
+2. Replace `your_resend_api_key_here` with your actual Resend API key:
+
+```env
+RESEND_API_KEY=re_your_actual_key_here
+PRAYER_REQUEST_EMAIL=theservingchurchdallas@gmail.com
+RESEND_FROM_EMAIL=onboarding@resend.dev
+```
+
+### Step 3: (Optional) Verify Your Domain
+
+For production use, you should verify your domain with Resend:
+
+1. In Resend dashboard, go to Domains
+2. Add your domain (e.g., `theservingchurch.org`)
+3. Follow the DNS verification steps
+4. Once verified, update `.env.local`:
+
+```env
+RESEND_FROM_EMAIL=noreply@theservingchurch.org
+```
+
+**Note**: Until you verify a domain, you can use `onboarding@resend.dev` which works but shows "via resend.dev" in emails.
+
+### Step 4: Test the Feature
+
+1. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+2. Navigate to: `http://localhost:3000/contact-us/prayer-request`
+
+3. Fill out the form and submit
+
+4. Check the email inbox at `theservingchurchdallas@gmail.com`
+
+5. Verify:
+   - Email arrives within seconds
+   - HTML formatting looks good
+   - Public/Private distinction is clear
+   - All form data is included
+   - Reply-to email works (if provided)
+
+## Email Preview
+
+### Public Prayer Request Email
+- **Color**: Blue theme
+- **Subject**: "Public Prayer Request from [Name]"
+- **Badge**: "PUBLIC"
+- **Note**: "May be shared with the congregation and prayer team"
+
+### Private Prayer Request Email
+- **Color**: Purple theme
+- **Subject**: "Private Prayer Request from [Name]"
+- **Badge**: "PRIVATE"
+- **Note**: "Only for pastoral staff and prayer team leaders"
+
+## Form Validation
+
+- **Name**: Required
+- **Email**: Optional, but validated if provided
+- **Prayer Request**: Required, minimum 10 characters
+- **Friendly error messages** shown below each field
+
+## Features
+
+1. ✅ **Public/Private Toggle**: Clear distinction between request types
+2. ✅ **Email Notifications**: Instant email to church staff
+3. ✅ **Professional Design**: Clean, modern UI with color-coded themes
+4. ✅ **Mobile Responsive**: Works on all device sizes
+5. ✅ **Form Validation**: Proper validation with helpful messages
+6. ✅ **Loading States**: Shows "Submitting..." during submission
+7. ✅ **Success Feedback**: Green success message on submission
+8. ✅ **Error Handling**: Red error message if something goes wrong
+9. ✅ **Auto-reset**: Form clears after successful submission
+10. ✅ **Reply-to Support**: Can reply directly to requester if email provided
+
+## Troubleshooting
+
+### Emails not arriving?
+
+1. **Check API Key**: Make sure your Resend API key is correct in `.env.local`
+2. **Check Spam**: Emails might be in spam folder
+3. **Check Resend Dashboard**: Log into Resend and check the Logs section
+4. **Check Console**: Look for errors in browser console or terminal
+
+### Build fails?
+
+- The build might fail due to network issues (Google Fonts). This doesn't affect the prayer request functionality.
+- If you see TypeScript errors about images, those are pre-existing and don't affect the prayer request feature.
+
+### Form not submitting?
+
+1. Open browser DevTools (F12)
+2. Go to Console tab
+3. Submit the form
+4. Look for error messages
+5. Check Network tab to see the API request/response
+
+## Production Deployment
+
+Before deploying to production:
+
+1. ✅ Set environment variables in your hosting platform (Vercel, Netlify, etc.):
+   - `RESEND_API_KEY`
+   - `PRAYER_REQUEST_EMAIL`
+   - `RESEND_FROM_EMAIL`
+
+2. ✅ Verify your domain with Resend
+
+3. ✅ Update `RESEND_FROM_EMAIL` to use your verified domain
+
+4. ✅ Test thoroughly on production before announcing
+
+## Future Enhancements (Optional)
+
+Consider adding these features later:
+
+- **Admin Dashboard**: View and manage prayer requests
+- **Database Storage**: Store prayer requests (Supabase, Prisma, etc.)
+- **Status Tracking**: Mark requests as "Praying", "Answered", etc.
+- **Prayer Wall**: Display public requests on the website
+- **Email Confirmations**: Send confirmation to requester
+- **Recurring Prayers**: Follow up after X days
+- **Prayer Teams**: Assign requests to different teams
+- **Analytics**: Track submission rates and trends
+
+## Support
+
+If you have questions or issues:
+
+1. Check Resend documentation: https://resend.com/docs
+2. Check Next.js API Routes: https://nextjs.org/docs/app/building-your-application/routing/route-handlers
+3. Review the code comments in `/src/app/api/prayer-requests/route.ts`
+
+---
+
+**Created by Claude Code**
+Date: 2025-11-05

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.51.3",
         "react-icons": "^5.0.1",
+        "resend": "^6.4.1",
         "tailwind-merge": "^2.2.2",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.0"
@@ -1063,6 +1064,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.2.tgz",
       "integrity": "sha512-hw437iINopmQuxWPSUEvqE56NCPsiU8N4AYtfHmJFckclktzK9YQJieD3XkDCDH4OjL+C7zgPUh73R/nrcHrqw==",
       "dev": true
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
@@ -2277,6 +2284,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -2753,6 +2766,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -4514,6 +4533,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4762,6 +4787,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.4.1.tgz",
+      "integrity": "sha512-+P1gF6bYT0lKd0vsYyKKTHd6PfMH37yDgNRA6wAARQgQbYlc2BZYuo9sB/uZKkVg1oGSh0cgpnxNKGsZJutXMg==",
+      "license": "MIT",
+      "dependencies": {
+        "svix": "1.76.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -5284,6 +5335,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svix": {
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
+      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.0.tgz",
+      "integrity": "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/svix/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.2.2.tgz",
@@ -5589,6 +5669,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
@@ -5634,6 +5724,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/warning": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.51.3",
     "react-icons": "^5.0.1",
+    "resend": "^6.4.1",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.0"

--- a/src/app/api/prayer-requests/route.ts
+++ b/src/app/api/prayer-requests/route.ts
@@ -1,0 +1,245 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+// Initialize Resend with API key from environment variables
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+// Type for the prayer request data
+interface PrayerRequestData {
+  name: string;
+  email?: string;
+  request: string;
+  isPublic: boolean;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    // Parse the request body
+    const body: PrayerRequestData = await request.json();
+    const { name, email, request: prayerRequest, isPublic } = body;
+
+    // Validate required fields
+    if (!name || !prayerRequest) {
+      return NextResponse.json(
+        { error: 'Name and prayer request are required' },
+        { status: 400 }
+      );
+    }
+
+    // Validate prayer request length
+    if (prayerRequest.length < 10) {
+      return NextResponse.json(
+        { error: 'Prayer request must be at least 10 characters' },
+        { status: 400 }
+      );
+    }
+
+    // Get email configuration from environment variables
+    const toEmail = process.env.PRAYER_REQUEST_EMAIL || 'theservingchurchdallas@gmail.com';
+    const fromEmail = process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev';
+
+    // Prepare email content
+    const requestType = isPublic ? 'Public' : 'Private';
+    const subject = `${requestType} Prayer Request from ${name}`;
+
+    const htmlContent = `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <style>
+            body {
+              font-family: Arial, sans-serif;
+              line-height: 1.6;
+              color: #333;
+              max-width: 600px;
+              margin: 0 auto;
+              padding: 20px;
+            }
+            .header {
+              background-color: ${isPublic ? '#3b82f6' : '#9333ea'};
+              color: white;
+              padding: 20px;
+              border-radius: 8px 8px 0 0;
+              margin-bottom: 20px;
+            }
+            .header h1 {
+              margin: 0;
+              font-size: 24px;
+            }
+            .badge {
+              display: inline-block;
+              background-color: ${isPublic ? '#1d4ed8' : '#6b21a8'};
+              color: white;
+              padding: 4px 12px;
+              border-radius: 12px;
+              font-size: 12px;
+              font-weight: bold;
+              margin-top: 8px;
+            }
+            .content {
+              background-color: #f9fafb;
+              padding: 20px;
+              border-radius: 0 0 8px 8px;
+            }
+            .field {
+              margin-bottom: 16px;
+            }
+            .label {
+              font-weight: bold;
+              color: #6b7280;
+              font-size: 12px;
+              text-transform: uppercase;
+              letter-spacing: 0.5px;
+              margin-bottom: 4px;
+            }
+            .value {
+              color: #111827;
+              font-size: 16px;
+            }
+            .request-text {
+              background-color: white;
+              padding: 16px;
+              border-radius: 6px;
+              border-left: 4px solid ${isPublic ? '#3b82f6' : '#9333ea'};
+              white-space: pre-wrap;
+              word-wrap: break-word;
+            }
+            .footer {
+              margin-top: 20px;
+              padding-top: 20px;
+              border-top: 1px solid #e5e7eb;
+              font-size: 12px;
+              color: #6b7280;
+              text-align: center;
+            }
+          </style>
+        </head>
+        <body>
+          <div class="header">
+            <h1>New Prayer Request</h1>
+            <span class="badge">${requestType.toUpperCase()}</span>
+          </div>
+
+          <div class="content">
+            <div class="field">
+              <div class="label">Submitted By</div>
+              <div class="value">${name}</div>
+            </div>
+
+            ${email ? `
+              <div class="field">
+                <div class="label">Email</div>
+                <div class="value"><a href="mailto:${email}">${email}</a></div>
+              </div>
+            ` : ''}
+
+            <div class="field">
+              <div class="label">Prayer Request</div>
+              <div class="request-text">${prayerRequest}</div>
+            </div>
+
+            <div class="field">
+              <div class="label">Request Type</div>
+              <div class="value">
+                ${isPublic
+                  ? 'Public - May be shared with the congregation and prayer team'
+                  : 'Private - Only for pastoral staff and prayer team leaders'}
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="label">Submitted</div>
+              <div class="value">${new Date().toLocaleString('en-US', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                timeZoneName: 'short'
+              })}</div>
+            </div>
+          </div>
+
+          <div class="footer">
+            <p>This prayer request was submitted through The Serving Church website.</p>
+            ${email ? `<p>You can reply directly to ${email} to follow up.</p>` : '<p>No email address was provided for follow-up.</p>'}
+          </div>
+        </body>
+      </html>
+    `;
+
+    const textContent = `
+New ${requestType} Prayer Request
+
+Submitted By: ${name}
+${email ? `Email: ${email}` : 'No email provided'}
+
+Prayer Request:
+${prayerRequest}
+
+Request Type: ${isPublic ? 'Public - May be shared with the congregation and prayer team' : 'Private - Only for pastoral staff and prayer team leaders'}
+
+Submitted: ${new Date().toLocaleString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short'
+    })}
+
+---
+This prayer request was submitted through The Serving Church website.
+${email ? `You can reply directly to ${email} to follow up.` : ''}
+    `.trim();
+
+    // Send email using Resend
+    const data = await resend.emails.send({
+      from: fromEmail,
+      to: toEmail,
+      subject: subject,
+      html: htmlContent,
+      text: textContent,
+      replyTo: email || undefined,
+    });
+
+    console.log('Prayer request email sent:', data);
+
+    // Return success response
+    return NextResponse.json(
+      {
+        success: true,
+        message: 'Prayer request submitted successfully',
+        id: data && 'data' in data ? data.data?.id : undefined
+      },
+      { status: 200 }
+    );
+
+  } catch (error) {
+    console.error('Error processing prayer request:', error);
+
+    // Return error response
+    return NextResponse.json(
+      {
+        error: 'Failed to submit prayer request',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// Handle OPTIONS request for CORS
+export async function OPTIONS(request: NextRequest) {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/src/app/api/prayer-requests/route.ts
+++ b/src/app/api/prayer-requests/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { Resend } from 'resend';
+import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
 
-// Initialize Resend with API key from environment variables
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Ensure Node runtime (Resend SDK expects Node) and no prerendering
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 // Type for the prayer request data
 interface PrayerRequestData {
@@ -14,218 +15,123 @@ interface PrayerRequestData {
 
 export async function POST(request: NextRequest) {
   try {
-    // Parse the request body
     const body: PrayerRequestData = await request.json();
     const { name, email, request: prayerRequest, isPublic } = body;
 
-    // Validate required fields
     if (!name || !prayerRequest) {
       return NextResponse.json(
-        { error: 'Name and prayer request are required' },
+        { error: "Name and prayer request are required" },
         { status: 400 }
       );
     }
-
-    // Validate prayer request length
     if (prayerRequest.length < 10) {
       return NextResponse.json(
-        { error: 'Prayer request must be at least 10 characters' },
+        { error: "Prayer request must be at least 10 characters" },
         { status: 400 }
       );
     }
 
-    // Get email configuration from environment variables
-    const toEmail = process.env.PRAYER_REQUEST_EMAIL || 'theservingchurchdallas@gmail.com';
-    const fromEmail = process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev';
+    // Read env once per request
+    const apiKey = process.env.RESEND_API_KEY;
+    const toEmail =
+      process.env.PRAYER_REQUEST_EMAIL || "theservingchurchdallas@gmail.com";
+    const fromEmail =
+      process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev";
 
-    // Prepare email content
-    const requestType = isPublic ? 'Public' : 'Private';
+    if (!apiKey) {
+      console.error("Missing RESEND_API_KEY");
+      return NextResponse.json(
+        { error: "Email service not configured" },
+        { status: 500 }
+      );
+    }
+
+    // ✅ Lazy-init Resend inside the handler
+    const resend = new Resend(apiKey);
+
+    const requestType = isPublic ? "Public" : "Private";
     const subject = `${requestType} Prayer Request from ${name}`;
 
+    const submittedAt = new Date().toLocaleString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZoneName: "short",
+    });
+
     const htmlContent = `
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta charset="utf-8">
-          <style>
-            body {
-              font-family: Arial, sans-serif;
-              line-height: 1.6;
-              color: #333;
-              max-width: 600px;
-              margin: 0 auto;
-              padding: 20px;
-            }
-            .header {
-              background-color: ${isPublic ? '#3b82f6' : '#9333ea'};
-              color: white;
-              padding: 20px;
-              border-radius: 8px 8px 0 0;
-              margin-bottom: 20px;
-            }
-            .header h1 {
-              margin: 0;
-              font-size: 24px;
-            }
-            .badge {
-              display: inline-block;
-              background-color: ${isPublic ? '#1d4ed8' : '#6b21a8'};
-              color: white;
-              padding: 4px 12px;
-              border-radius: 12px;
-              font-size: 12px;
-              font-weight: bold;
-              margin-top: 8px;
-            }
-            .content {
-              background-color: #f9fafb;
-              padding: 20px;
-              border-radius: 0 0 8px 8px;
-            }
-            .field {
-              margin-bottom: 16px;
-            }
-            .label {
-              font-weight: bold;
-              color: #6b7280;
-              font-size: 12px;
-              text-transform: uppercase;
-              letter-spacing: 0.5px;
-              margin-bottom: 4px;
-            }
-            .value {
-              color: #111827;
-              font-size: 16px;
-            }
-            .request-text {
-              background-color: white;
-              padding: 16px;
-              border-radius: 6px;
-              border-left: 4px solid ${isPublic ? '#3b82f6' : '#9333ea'};
-              white-space: pre-wrap;
-              word-wrap: break-word;
-            }
-            .footer {
-              margin-top: 20px;
-              padding-top: 20px;
-              border-top: 1px solid #e5e7eb;
-              font-size: 12px;
-              color: #6b7280;
-              text-align: center;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="header">
-            <h1>New Prayer Request</h1>
-            <span class="badge">${requestType.toUpperCase()}</span>
-          </div>
-
-          <div class="content">
-            <div class="field">
-              <div class="label">Submitted By</div>
-              <div class="value">${name}</div>
-            </div>
-
-            ${email ? `
-              <div class="field">
-                <div class="label">Email</div>
-                <div class="value"><a href="mailto:${email}">${email}</a></div>
-              </div>
-            ` : ''}
-
-            <div class="field">
-              <div class="label">Prayer Request</div>
-              <div class="request-text">${prayerRequest}</div>
-            </div>
-
-            <div class="field">
-              <div class="label">Request Type</div>
-              <div class="value">
-                ${isPublic
-                  ? 'Public - May be shared with the congregation and prayer team'
-                  : 'Private - Only for pastoral staff and prayer team leaders'}
-              </div>
-            </div>
-
-            <div class="field">
-              <div class="label">Submitted</div>
-              <div class="value">${new Date().toLocaleString('en-US', {
-                weekday: 'long',
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-                hour: '2-digit',
-                minute: '2-digit',
-                timeZoneName: 'short'
-              })}</div>
-            </div>
-          </div>
-
-          <div class="footer">
-            <p>This prayer request was submitted through The Serving Church website.</p>
-            ${email ? `<p>You can reply directly to ${email} to follow up.</p>` : '<p>No email address was provided for follow-up.</p>'}
-          </div>
-        </body>
-      </html>
+      <!doctype html>
+      <html><head><meta charset="utf-8">
+        <style>
+          body{font-family:Arial,system-ui;line-height:1.6;color:#333;max-width:600px;margin:0 auto;padding:20px}
+          .header{background:${isPublic ? "#3b82f6" : "#9333ea"};color:#fff;padding:20px;border-radius:8px 8px 0 0;margin-bottom:20px}
+          .badge{display:inline-block;background:${isPublic ? "#1d4ed8" : "#6b21a8"};color:#fff;padding:4px 12px;border-radius:12px;font:bold 12px/1 Arial;margin-top:8px}
+          .content{background:#f9fafb;padding:20px;border-radius:0 0 8px 8px}
+          .field{margin-bottom:16px}
+          .label{font-weight:bold;color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:.5px;margin-bottom:4px}
+          .value{color:#111827;font-size:16px}
+          .request-text{background:#fff;padding:16px;border-radius:6px;border-left:4px solid ${isPublic ? "#3b82f6" : "#9333ea"};white-space:pre-wrap;word-wrap:break-word}
+          .footer{margin-top:20px;padding-top:20px;border-top:1px solid #e5e7eb;font-size:12px;color:#6b7280;text-align:center}
+        </style>
+      </head>
+      <body>
+        <div class="header">
+          <h1>New Prayer Request</h1>
+          <span class="badge">${requestType.toUpperCase()}</span>
+        </div>
+        <div class="content">
+          <div class="field"><div class="label">Submitted By</div><div class="value">${name}</div></div>
+          ${email ? `<div class="field"><div class="label">Email</div><div class="value"><a href="mailto:${email}">${email}</a></div></div>` : ""}
+          <div class="field"><div class="label">Prayer Request</div><div class="request-text">${prayerRequest}</div></div>
+          <div class="field"><div class="label">Request Type</div><div class="value">${isPublic ? "Public - May be shared with the congregation and prayer team" : "Private - Only for pastoral staff and prayer team leaders"}</div></div>
+          <div class="field"><div class="label">Submitted</div><div class="value">${submittedAt}</div></div>
+        </div>
+        <div class="footer">
+          <p>This prayer request was submitted through The Serving Church website.</p>
+          ${email ? `<p>You can reply directly to ${email} to follow up.</p>` : "<p>No email address was provided for follow-up.</p>"}
+        </div>
+      </body></html>
     `;
 
-    const textContent = `
-New ${requestType} Prayer Request
+    const textContent = [
+      `New ${requestType} Prayer Request`,
+      `Submitted By: ${name}`,
+      email ? `Email: ${email}` : "No email provided",
+      "Prayer Request:",
+      prayerRequest,
+      `Request Type: ${isPublic ? "Public - May be shared with the congregation and prayer team" : "Private - Only for pastoral staff and prayer team leaders"}`,
+      `Submitted: ${submittedAt}`,
+      "---",
+      "This prayer request was submitted through The Serving Church website.",
+      email ? `You can reply directly to ${email} to follow up.` : "",
+    ].join("\n");
 
-Submitted By: ${name}
-${email ? `Email: ${email}` : 'No email provided'}
-
-Prayer Request:
-${prayerRequest}
-
-Request Type: ${isPublic ? 'Public - May be shared with the congregation and prayer team' : 'Private - Only for pastoral staff and prayer team leaders'}
-
-Submitted: ${new Date().toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      timeZoneName: 'short'
-    })}
-
----
-This prayer request was submitted through The Serving Church website.
-${email ? `You can reply directly to ${email} to follow up.` : ''}
-    `.trim();
-
-    // Send email using Resend
     const data = await resend.emails.send({
       from: fromEmail,
       to: toEmail,
-      subject: subject,
+      subject,
       html: htmlContent,
       text: textContent,
       replyTo: email || undefined,
     });
 
-    console.log('Prayer request email sent:', data);
-
-    // Return success response
     return NextResponse.json(
       {
         success: true,
-        message: 'Prayer request submitted successfully',
-        id: data && 'data' in data ? data.data?.id : undefined
+        message: "Prayer request submitted successfully",
+        id: (data as any)?.data?.id,
       },
       { status: 200 }
     );
-
   } catch (error) {
-    console.error('Error processing prayer request:', error);
-
-    // Return error response
+    console.error("Error processing prayer request:", error);
     return NextResponse.json(
       {
-        error: 'Failed to submit prayer request',
-        details: error instanceof Error ? error.message : 'Unknown error'
+        error: "Failed to submit prayer request",
+        details: error instanceof Error ? error.message : "Unknown error",
       },
       { status: 500 }
     );
@@ -233,13 +139,14 @@ ${email ? `You can reply directly to ${email} to follow up.` : ''}
 }
 
 // Handle OPTIONS request for CORS
-export async function OPTIONS(request: NextRequest) {
+export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
     },
   });
 }
+

--- a/src/app/contact-us/page.tsx
+++ b/src/app/contact-us/page.tsx
@@ -29,18 +29,18 @@ const ContactUsPage = () => {
         <div className="p-4">
           <h2 className="text-2xl font-semibold">Contact Information</h2>
           <p><strong>Address:</strong> 222 Collins Rd, Sunnyvale, Texas, 75182</p>
-          <p><strong>Phone:</strong> (123) 456-7890</p>
-          <p><strong>Email:</strong> info@yourchurch.com</p>
+          <p><strong>Phone:</strong> (214) 738-6371</p>
+          <p><strong>Email:</strong> theservingchurchdallas@gmail.com</p>
         </div>
       </Card>
       <div className="grid grid-cols-2 gap-4">
         <Button asChild>
-          <Link href="/contact-church">
+          <Link href="/contact-us/contact-church">
             <div className="w-full h-full inline-flex justify-center items-center">Contact Church</div>
           </Link>
         </Button>
         <Button asChild>
-          <Link href="/prayer-request">
+          <Link href="/contact-us/prayer-request">
             <div className="w-full h-full inline-flex justify-center items-center">Prayer Requests</div>
           </Link>
         </Button>


### PR DESCRIPTION
This commit makes the prayer request page fully operational with email notifications.

Changes:
- Enhanced prayer request form with email field and textarea
- Added proper form validation (name, email, request length)
- Implemented loading states and success/error feedback
- Created API endpoint at /api/prayer-requests
- Integrated Resend email service for notifications
- Designed professional HTML email templates with color coding
  - Blue theme for public prayer requests
  - Purple theme for private prayer requests
- Added environment variable configuration (.env.example)
- Fixed incorrect links in contact-us page (/prayer-request -> /contact-us/prayer-request)
- Updated contact information to match church details
- Created comprehensive setup documentation (PRAYER_REQUEST_SETUP.md)

Features:
- Public/Private prayer request distinction
- Optional email field for follow-up
- Reply-to support in notification emails
- Responsive design matching site theme
- Form auto-reset after successful submission
- Detailed timestamp and submission information in emails

Dependencies:
- Added resend package for email delivery

Setup Required:
- Add RESEND_API_KEY to .env.local (see PRAYER_REQUEST_SETUP.md)