### PR TITLE
fix: remove excessive pulse animation from Get Directions button

### DIFF
--- a/src/components/welcomesection.tsx
+++ b/src/components/welcomesection.tsx
@@ -39,7 +39,7 @@ export function WelcomeSection() {
         <Link href="/location">
           <Button
             size="lg"
-            className="group relative overflow-hidden bg-gradient-to-r from-green-600 via-emerald-600 to-teal-600 hover:from-green-700 hover:via-emerald-700 hover:to-teal-700 text-white px-8 py-6 rounded-full shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:scale-105 animate-pulse hover:animate-none"
+            className="group relative overflow-hidden bg-gradient-to-r from-green-600 via-emerald-600 to-teal-600 hover:from-green-700 hover:via-emerald-700 hover:to-teal-700 text-white px-8 py-6 rounded-full shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:scale-105"
           >
             <div className="absolute inset-0 bg-gradient-to-r from-emerald-400 to-green-400 opacity-0 group-hover:opacity-20 blur-xl transition-opacity duration-300" />
             <div className="relative flex items-center justify-center gap-2 text-base md:text-lg font-semibold">


### PR DESCRIPTION
Removed animate-pulse class that was flashing too fast/much. Button now has subtle hover effects (scale + glow) without constant animation, making it less distracting while still prominent.