### PR TITLE
fix: resolve navigation dropdown alignment and logo sizing issues

### DIFF
--- a/src/components/component/navcomponent.tsx
+++ b/src/components/component/navcomponent.tsx
@@ -32,16 +32,18 @@ export function NavComponent() {
   return (
     <React.Suspense fallback={<Skeleton className="w-[100px] h-[20px] rounded-full" />}>
       <header className="flex h-20 w-full items-center px-4 md:px-6 sticky top-0 z-50 backdrop-blur-md bg-white bg-opacity-90 justify-between">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 shrink-0">
           <Link href="/" passHref>
             <div className="flex gap-2 text-lg font-semibold md:text-base">
-              <Image
-                src={SUPABASE_IMAGES.logowordhome}
-                width={140}
-                height={35}
-                alt="The Serving Church Logo"
-                priority
-              />
+              <div className="relative w-[140px] h-[35px] shrink-0">
+                <Image
+                  src={SUPABASE_IMAGES.logowordhome}
+                  fill
+                  alt="The Serving Church Logo"
+                  priority
+                  className="object-contain"
+                />
+              </div>
               <span className="sr-only">Serving Church</span>
             </div>
           </Link>
@@ -217,8 +219,8 @@ export function NavComponent() {
             </SheetContent>
           </Sheet>
         </div>
-        <div className="hidden lg:flex w-full justify-center">
-          <NavigationMenu className="hidden lg:flex">
+        <div className="hidden lg:flex flex-1 justify-center">
+          <NavigationMenu>
             <NavigationMenuList>
               <NavigationMenuItem>
                 <NavigationMenuLink asChild>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -10,7 +10,7 @@ export function MovementComponent() {
         src={SUPABASE_IMAGES.samwise}
         alt="Church community gathering - The Serving Church"
         fill
-        className="object-cover"
+        className="object-cover animate-[zoom-in_1.5s_ease-out]"
         style={{ objectPosition: "80% center" }}
         priority
         sizes="100vw"
@@ -18,20 +18,64 @@ export function MovementComponent() {
       <div className="absolute inset-0 bg-gradient-to-r from-black/80 via-black/40 to-transparent" />
       <div className="absolute inset-0 flex items-center justify-center px-4 md:px-6">
         <div className="max-w-4xl w-full text-center md:text-left">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-white drop-shadow-lg">
-            <span className="block bg-slate-900/40 backdrop-blur-sm rounded-lg p-4 md:p-6">
-              A{" "}
-              <strong className="text-transparent font-extrabold bg-gradient-to-br from-blue-300 to-rose-500 bg-clip-text">
-                FAMILY
+          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-white drop-shadow-lg animate-[fade-in-up_1s_ease-out]">
+            <span className="block bg-slate-900/40 backdrop-blur-sm rounded-lg p-4 md:p-6 border border-white/10 shadow-2xl">
+              <span className="inline-block animate-[fade-in-up_0.8s_ease-out_0.2s_both]">
+                A{" "}
+              </span>
+              <strong className="inline-block relative text-transparent font-extrabold bg-gradient-to-br from-blue-300 via-purple-400 to-rose-500 bg-clip-text animate-[fade-in-up_0.8s_ease-out_0.4s_both,gradient-shift_4s_ease-in-out_infinite] bg-[length:200%_200%]">
+                <span className="relative">
+                  FAMILY
+                  <span className="absolute inset-0 blur-xl bg-gradient-to-br from-blue-400 to-rose-400 opacity-50 animate-pulse"></span>
+                </span>
               </strong>{" "}
-              TRYING TO LOOK LIKE{" "}
-              <strong className="text-transparent font-extrabold bg-gradient-to-b from-amber-300 to-orange-500 bg-clip-text">
-                CHRIST
+              <span className="inline-block animate-[fade-in-up_0.8s_ease-out_0.6s_both]">
+                TRYING TO
+              </span>{" "}
+              <span className="inline-block animate-[fade-in-up_0.8s_ease-out_0.8s_both]">
+                LOOK LIKE
+              </span>{" "}
+              <strong className="inline-block relative text-transparent font-extrabold bg-gradient-to-br from-amber-300 via-orange-400 to-orange-500 bg-clip-text animate-[fade-in-up_0.8s_ease-out_1s_both,gradient-shift_4s_ease-in-out_infinite] bg-[length:200%_200%]">
+                <span className="relative">
+                  CHRIST
+                  <span className="absolute inset-0 blur-xl bg-gradient-to-br from-amber-400 to-orange-400 opacity-50 animate-pulse"></span>
+                </span>
               </strong>
             </span>
           </h1>
         </div>
       </div>
+
+      <style jsx>{`
+        @keyframes fade-in-up {
+          from {
+            opacity: 0;
+            transform: translateY(30px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+
+        @keyframes zoom-in {
+          from {
+            transform: scale(1.1);
+          }
+          to {
+            transform: scale(1);
+          }
+        }
+
+        @keyframes gradient-shift {
+          0%, 100% {
+            background-position: 0% 50%;
+          }
+          50% {
+            background-position: 100% 50%;
+          }
+        }
+      `}</style>
     </section>
   );
 }

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -83,10 +83,10 @@ const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
-  <div className="absolute left-0 top-full flex">
+  <div className={cn("absolute left-0 top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className
       )}
       ref={ref}


### PR DESCRIPTION
- Fix navigation dropdown positioning by using flex-1 instead of w-full
  - Dropdowns now correctly appear under their trigger buttons
  - Maintain shadcn viewport pattern with proper centering
- Fix logo shrinking on page resize
  - Wrap logo in fixed-size container with shrink-0
  - Logo maintains 140x35px dimensions at all viewport sizes
- Enhance hero banner text with artistic animations
  - Add staggered fade-in-up animation for cascading word reveal
  - Implement animated gradient shift on "FAMILY" and "CHRIST"
  - Add glow/pulse effects for depth and visual interest
  - Apply cinematic zoom-in effect to background image
  - Enhance container with border and shadow for better definition