### PR TITLE
fix: resolve logo sizing, navigation alignment, and banner text visib…

### DIFF
--- a/src/components/component/navcomponent.tsx
+++ b/src/components/component/navcomponent.tsx
@@ -35,15 +35,14 @@ export function NavComponent() {
         <div className="flex items-center gap-2 shrink-0">
           <Link href="/" passHref>
             <div className="flex gap-2 text-lg font-semibold md:text-base">
-              <div className="relative w-[140px] h-[35px] shrink-0">
-                <Image
-                  src={SUPABASE_IMAGES.logowordhome}
-                  fill
-                  alt="The Serving Church Logo"
-                  priority
-                  className="object-contain"
-                />
-              </div>
+              <Image
+                src={SUPABASE_IMAGES.logowordhome}
+                width={140}
+                height={35}
+                alt="The Serving Church Logo"
+                priority
+                style={{ width: '140px', height: '35px' }}
+              />
               <span className="sr-only">Serving Church</span>
             </div>
           </Link>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -23,11 +23,8 @@ export function MovementComponent() {
               <span className="inline-block animate-[fade-in-up_0.8s_ease-out_0.2s_both]">
                 A{" "}
               </span>
-              <strong className="inline-block relative text-transparent font-extrabold bg-gradient-to-br from-blue-300 via-purple-400 to-rose-500 bg-clip-text animate-[fade-in-up_0.8s_ease-out_0.4s_both,gradient-shift_4s_ease-in-out_infinite] bg-[length:200%_200%]">
-                <span className="relative">
-                  FAMILY
-                  <span className="absolute inset-0 blur-xl bg-gradient-to-br from-blue-400 to-rose-400 opacity-50 animate-pulse"></span>
-                </span>
+              <strong className="inline-block font-extrabold text-transparent bg-gradient-to-br from-blue-300 via-purple-400 to-rose-500 bg-clip-text animate-[fade-in-up_0.8s_ease-out_0.4s_both,gradient-shift_4s_ease-in-out_infinite] bg-[length:200%_200%] drop-shadow-[0_0_30px_rgba(147,51,234,0.5)]">
+                FAMILY
               </strong>{" "}
               <span className="inline-block animate-[fade-in-up_0.8s_ease-out_0.6s_both]">
                 TRYING TO
@@ -35,11 +32,8 @@ export function MovementComponent() {
               <span className="inline-block animate-[fade-in-up_0.8s_ease-out_0.8s_both]">
                 LOOK LIKE
               </span>{" "}
-              <strong className="inline-block relative text-transparent font-extrabold bg-gradient-to-br from-amber-300 via-orange-400 to-orange-500 bg-clip-text animate-[fade-in-up_0.8s_ease-out_1s_both,gradient-shift_4s_ease-in-out_infinite] bg-[length:200%_200%]">
-                <span className="relative">
-                  CHRIST
-                  <span className="absolute inset-0 blur-xl bg-gradient-to-br from-amber-400 to-orange-400 opacity-50 animate-pulse"></span>
-                </span>
+              <strong className="inline-block font-extrabold text-transparent bg-gradient-to-br from-amber-300 via-orange-400 to-orange-500 bg-clip-text animate-[fade-in-up_0.8s_ease-out_1s_both,gradient-shift_4s_ease-in-out_infinite] bg-[length:200%_200%] drop-shadow-[0_0_30px_rgba(251,146,60,0.5)]">
+                CHRIST
               </strong>
             </span>
           </h1>

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -83,10 +83,10 @@ const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
-  <div className={cn("absolute left-0 top-full flex justify-center")}>
+  <div className={cn("absolute right-0 top-full flex justify-end")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+        "origin-top-right relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className
       )}
       ref={ref}


### PR DESCRIPTION
…ility

- Fix logo displaying too small by reverting to width/height props with inline style
  - Logo now maintains proper 140x35px dimensions
- Align navigation dropdowns to the right side as requested
  - Changed viewport from left-0 justify-center to right-0 justify-end
  - Changed origin from top-center to top-right
  - Dropdowns now consistently appear on right side
- Fix FAMILY and CHRIST text disappearing in banner
  - Removed nested span structure that was hiding text
  - Simplified gradient implementation while keeping animations
  - Text now visible with animated gradients and glow effects