### PR TITLE
fix: increase logo size on mobile devices for better visibility

### DIFF
--- a/src/components/component/navcomponent.tsx
+++ b/src/components/component/navcomponent.tsx
@@ -41,7 +41,7 @@ export function NavComponent() {
                 height={35}
                 alt="The Serving Church Logo"
                 priority
-                style={{ width: '140px', height: '35px' }}
+                className="w-[180px] h-auto md:w-[140px]"
               />
               <span className="sr-only">Serving Church</span>
             </div>
@@ -64,6 +64,7 @@ export function NavComponent() {
                     width={140}
                     height={35}
                     alt="The Serving Church Logo"
+                    className="w-[160px] h-auto"
                   />
                   <span className="sr-only">Serving Church</span>
                 </Link>


### PR DESCRIPTION
- Main nav logo: 180px on mobile, 140px on desktop
- Mobile sheet logo: 160px for better visibility
- Use h-auto to maintain aspect ratio
- Remove fixed inline styles that prevented responsive sizing