### PR TITLE
fix: adjust mobile logo size to optimal 155px

### DIFF
--- a/src/components/component/navcomponent.tsx
+++ b/src/components/component/navcomponent.tsx
@@ -41,7 +41,7 @@ export function NavComponent() {
                 height={35}
                 alt="The Serving Church Logo"
                 priority
-                className="w-[180px] h-auto md:w-[140px]"
+                className="w-[155px] h-auto md:w-[140px]"
               />
               <span className="sr-only">Serving Church</span>
             </div>
@@ -64,7 +64,7 @@ export function NavComponent() {
                     width={140}
                     height={35}
                     alt="The Serving Church Logo"
-                    className="w-[160px] h-auto"
+                    className="w-[150px] h-auto"
                   />
                   <span className="sr-only">Serving Church</span>
                 </Link>


### PR DESCRIPTION
- Reduce main nav logo from 180px to 155px on mobile
- Reduce mobile sheet logo from 160px to 150px
- Better balance between visibility and space utilization