### PR TITLE
fix: standardize mobile logo size to 150px across all mobile views

### DIFF
--- a/src/components/component/navcomponent.tsx
+++ b/src/components/component/navcomponent.tsx
@@ -41,7 +41,7 @@ export function NavComponent() {
                 height={35}
                 alt="The Serving Church Logo"
                 priority
-                className="w-[155px] h-auto md:w-[140px]"
+                className="w-[150px] h-auto md:w-[140px]"
               />
               <span className="sr-only">Serving Church</span>
             </div>


### PR DESCRIPTION
- Set main nav logo to 150px on mobile (consistent with sheet)
- Mobile sheet logo already at 150px
- Desktop remains at 140px
- Tested across multiple mobile device sizes for optimal visibility