### PR TITLE
fix: make migrations 004 and 005 idempotent and safe to re-run

### DIFF
--- a/supabase/migrations/005_link_prayers_to_members.sql
+++ b/supabase/migrations/005_link_prayers_to_members.sql
@@ -1,19 +1,19 @@
--- Add member linkage and privacy settings to prayer_requests table
+-- Add member linkage and privacy settings to prayers table
 
--- Add new columns to prayer_requests
-ALTER TABLE public.prayer_requests
+-- Add new columns to prayers
+ALTER TABLE public.prayers
   ADD COLUMN IF NOT EXISTS member_id UUID REFERENCES public.members(id) ON DELETE SET NULL,
   ADD COLUMN IF NOT EXISTS show_name BOOLEAN DEFAULT TRUE;
 
 -- Create index for faster queries
-CREATE INDEX IF NOT EXISTS idx_prayer_requests_member_id ON public.prayer_requests(member_id);
+CREATE INDEX IF NOT EXISTS idx_prayers_member_id ON public.prayers(member_id);
 
 -- Update RLS policies to allow members to see their own private prayers
 -- Drop existing policies if they exist
-DROP POLICY IF EXISTS "Members can view their own prayers" ON public.prayer_requests;
+DROP POLICY IF EXISTS "Members can view their own prayers" ON public.prayers;
 
 -- Create new policy for members to view their own prayers (both public and private)
-CREATE POLICY "Members can view their own prayers" ON public.prayer_requests
+CREATE POLICY "Members can view their own prayers" ON public.prayers
   FOR SELECT TO authenticated
   USING (
     member_id = auth.uid()


### PR DESCRIPTION
- Add DROP POLICY IF EXISTS to all policies in 004_events_table.sql
- Make default event inserts conditional to prevent duplicates
- Fix table name from prayer_requests to prayers in 005
- All migrations now safe to run multiple times