### PR TITLE
fix: exclude Supabase functions from Next.js build

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,12 @@
+# Supabase Edge Functions (deployed separately to Supabase)
+supabase/functions
+
+# Supabase migrations (run directly in Supabase)
+supabase/migrations
+
+# Documentation
+docs
+
+# Local environment files
+.env.local
+.env*.local

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase"]
 }


### PR DESCRIPTION
- Updated tsconfig.json to exclude supabase/ directory from TypeScript compilation
- Added .vercelignore to prevent Vercel from processing Edge Functions
- Edge Functions are Deno code meant for Supabase deployment, not Next.js build

Fixes Vercel build error: 'Cannot find module https://deno.land/std@0.168.0/http/server.ts'