### PR TITLE
feat: add prayer deletion for admin/pastor users

### DIFF
--- a/src/app/admin/prayers/page.tsx
+++ b/src/app/admin/prayers/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Trash2 } from "lucide-react";
 
 export default function AdminPrayersPage() {
   const [prayers, setPrayers] = useState<Prayer[]>([]);
@@ -86,6 +87,31 @@ export default function AdminPrayersPage() {
       }
     } catch (error) {
       console.error("Error archiving prayer:", error);
+    }
+  };
+
+  const deletePrayer = async (id: string, prayerText: string) => {
+    // Confirm deletion with preview of prayer text
+    const confirmed = confirm(
+      `Are you sure you want to permanently delete this prayer?\n\n"${prayerText.slice(0, 100)}${prayerText.length > 100 ? '...' : ''}"\n\nThis action cannot be undone.`
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const response = await fetch(`/api/admin/prayers/${id}`, {
+        method: "DELETE",
+      });
+
+      if (response.ok) {
+        fetchPrayers(); // Refresh list
+      } else {
+        const data = await response.json();
+        alert(`Failed to delete prayer: ${data.error || 'Unknown error'}`);
+      }
+    } catch (error) {
+      console.error("Error deleting prayer:", error);
+      alert("An error occurred while deleting the prayer. Please try again.");
     }
   };
 
@@ -228,6 +254,15 @@ export default function AdminPrayersPage() {
                       className="text-gray-600"
                     >
                       Archive
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => deletePrayer(prayer.id, prayer.request)}
+                      className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                    >
+                      <Trash2 className="w-4 h-4 mr-1" />
+                      Delete
                     </Button>
                   </div>
                 </CardContent>

--- a/supabase/migrations/009_admin_prayer_management.sql
+++ b/supabase/migrations/009_admin_prayer_management.sql
@@ -1,0 +1,71 @@
+-- Admin & Pastor Prayer Management Permissions
+-- Allows admins and pastors to:
+-- - Update prayer status (new, praying, answered, ongoing, archived, public, quarantine, hidden)
+-- - Delete prayers (spam, inappropriate, duplicates)
+-- - View all prayers including hidden ones
+
+-- Drop existing service-role-only UPDATE policy
+DROP POLICY IF EXISTS "update_via_service_role" ON public.prayers;
+
+-- Allow service role to update (for Edge Functions)
+CREATE POLICY "update_via_service_role" ON public.prayers
+  FOR UPDATE
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Allow admin/pastor to update prayers (change status, mark answered, etc.)
+CREATE POLICY "admin_pastor_update_prayers" ON public.prayers
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.members
+      WHERE id = auth.uid() AND role IN ('pastor', 'admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.members
+      WHERE id = auth.uid() AND role IN ('pastor', 'admin')
+    )
+  );
+
+-- Allow admin/pastor to delete prayers
+CREATE POLICY "admin_pastor_delete_prayers" ON public.prayers
+  FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.members
+      WHERE id = auth.uid() AND role IN ('pastor', 'admin')
+    )
+  );
+
+-- Allow admin/pastor to view ALL prayers (including hidden ones) for moderation
+DROP POLICY IF EXISTS "read_visible_prayers" ON public.prayers;
+
+-- Public can read only public and quarantine prayers (not hidden)
+CREATE POLICY "public_read_visible_prayers" ON public.prayers
+  FOR SELECT
+  USING (
+    status IN ('public', 'quarantine', 'answered')
+    AND (auth.role() = 'anon' OR auth.role() = 'authenticated')
+  );
+
+-- Admin/Pastor can read ALL prayers including hidden ones
+CREATE POLICY "admin_pastor_read_all_prayers" ON public.prayers
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.members
+      WHERE id = auth.uid() AND role IN ('pastor', 'admin')
+    )
+  );
+
+-- Comment explaining the policy structure
+COMMENT ON POLICY "admin_pastor_delete_prayers" ON public.prayers IS
+  'Allows pastor and admin roles to delete prayers (spam, inappropriate content, duplicates)';
+
+COMMENT ON POLICY "admin_pastor_update_prayers" ON public.prayers IS
+  'Allows pastor and admin roles to update prayer status and moderate content';
+
+COMMENT ON POLICY "admin_pastor_read_all_prayers" ON public.prayers IS
+  'Allows pastor and admin roles to view all prayers including hidden ones for moderation';


### PR DESCRIPTION
Added ability for admin and pastor users to permanently delete prayers from the admin dashboard.

Database changes (migration 009):
- Added RLS policy for admin/pastor to delete prayers
- Added RLS policy for admin/pastor to update prayers (status changes)
- Added RLS policy for admin/pastor to view ALL prayers including hidden ones
- Updated read policies to separate public vs admin access

Frontend changes:
- Added deletePrayer function with confirmation dialog
- Added red "Delete" button with trash icon to admin prayers page
- Shows prayer preview in confirmation (first 100 chars)
- Refreshes prayer list after successful deletion
- Proper error handling with user feedback

Use cases:
- Remove spam that got through filters
- Delete inappropriate content
- Remove duplicate prayer requests
- Clean up test data

Confirmation dialog prevents accidental deletions.