### PR TITLE
fix: reduce spam triggers in password reset email template

### DIFF
--- a/email-template-password-reset.html
+++ b/email-template-password-reset.html
@@ -24,7 +24,7 @@
 
   <!-- Preheader Text -->
   <div style="display: none; max-height: 0; overflow: hidden; opacity: 0;">
-    Reset your password for The Serving Church member portal. Click to create a new password.
+    You requested to update your password for The Serving Church member portal.
   </div>
 
   <!-- Main Container -->
@@ -67,7 +67,7 @@
                     </div>
 
                     <h1 style="margin: 0 0 8px 0; color: #ffffff; font-size: 32px; font-weight: 800; line-height: 1.2; letter-spacing: -0.5px; text-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);">
-                      Password Reset Request
+                      Update Your Password
                     </h1>
                     <p style="margin: 0; color: rgba(255, 255, 255, 0.95); font-size: 17px; font-weight: 500; letter-spacing: 0.3px;">
                       The Serving Church
@@ -89,7 +89,7 @@
                 <tr>
                   <td style="background: linear-gradient(135deg, #fef2f2 0%, #fff7ed 100%); border: 2px solid #fecaca; border-radius: 100px; padding: 8px 20px;">
                     <span style="color: #dc2626; font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;">
-                      🔐 Security Alert
+                      🔐 Account Update
                     </span>
                   </td>
                 </tr>
@@ -97,16 +97,16 @@
 
               <!-- Main Heading -->
               <h2 style="margin: 0 0 24px 0; color: #0f172a; font-size: 28px; font-weight: 800; line-height: 1.3; text-align: center; letter-spacing: -0.5px;">
-                Let's Reset Your Password
+                Update Your Password
               </h2>
 
               <!-- Main Message -->
               <p style="margin: 0 0 20px 0; color: #475569; font-size: 17px; line-height: 1.7; text-align: center; font-weight: 400;">
-                We received a request to reset your password for your member account. Click the button below to create a new password.
+                You recently requested to change your password for your member account. Use the button below to create a new one.
               </p>
 
               <p style="margin: 0 0 36px 0; color: #64748b; font-size: 16px; line-height: 1.6; text-align: center;">
-                This link will expire in <strong style="color: #dc2626;">1 hour</strong> for security reasons.
+                This link expires in <strong style="color: #dc2626;">1 hour</strong> to keep your account safe.
               </p>
 
               <!-- CTA Button -->
@@ -117,7 +117,7 @@
                       <tr>
                         <td style="border-radius: 14px; background: linear-gradient(135deg, #dc2626 0%, #ea580c 100%); box-shadow: 0 10px 30px rgba(220, 38, 38, 0.35), 0 4px 10px rgba(234, 88, 12, 0.2);">
                           <a href="{{ .ConfirmationURL }}" style="display: inline-block; background: transparent; color: #ffffff; text-decoration: none; padding: 18px 48px; border-radius: 14px; font-size: 17px; font-weight: 700; letter-spacing: 0.3px; border: 2px solid rgba(255, 255, 255, 0.2);">
-                            🔑 Reset My Password
+                            🔑 Update Password
                           </a>
                         </td>
                       </tr>
@@ -155,11 +155,11 @@
                     </table>
 
                     <p style="margin: 0 0 16px 0; color: #991b1b; font-size: 15px; line-height: 1.7;">
-                      If you didn't request a password reset, please <strong>ignore this email</strong> or contact us immediately if you're concerned about your account security.
+                      If you didn't make this request, you can safely <strong>ignore this email</strong>. Feel free to contact us if you have any questions about your account.
                     </p>
 
                     <p style="margin: 0; color: #b91c1c; font-size: 14px; line-height: 1.6;">
-                      Your password will remain unchanged unless you click the reset link above.
+                      Your password will remain unchanged unless you use the link above.
                     </p>
                   </td>
                 </tr>
@@ -217,9 +217,9 @@
               <div style="margin: 24px 0; height: 1px; background: linear-gradient(90deg, transparent, #e2e8f0, transparent);"></div>
 
               <p style="margin: 0; color: #94a3b8; font-size: 12px; line-height: 1.7; text-align: center;">
-                This password reset was requested for <strong style="color: #64748b;">{{ .Email }}</strong>
+                This password update was requested for <strong style="color: #64748b;">{{ .Email }}</strong>
                 <br/>
-                If you didn't make this request, please ignore this email.
+                If you didn't make this request, you can safely disregard this message.
               </p>
             </td>
           </tr>


### PR DESCRIPTION
Updated language to avoid common phishing phrases:
- Changed "Security Alert" to "Account Update"
- Changed "Password Reset Request" to "Update Your Password"
- Replaced "Click" with "Use" (less commanding)
- Removed "immediately" and urgency language
- Softened "account security" to "your account"
- Changed "reset" to "update" throughout
- More conversational, less alarming tone

This should improve email deliverability and reduce spam flags.