### PR TITLE
fix: reduce spam triggers in reauthentication email template

### DIFF
--- a/email-template-reauthentication.html
+++ b/email-template-reauthentication.html
@@ -24,7 +24,7 @@
 
   <!-- Preheader Text -->
   <div style="display: none; max-height: 0; overflow: hidden; opacity: 0;">
-    Verify your identity to continue with your account action at The Serving Church.
+    Confirm your recent account activity at The Serving Church member portal.
   </div>
 
   <!-- Main Container -->
@@ -64,7 +64,7 @@
                     </div>
 
                     <h1 style="margin: 0 0 8px 0; color: #ffffff; font-size: 32px; font-weight: 800; line-height: 1.2; letter-spacing: -0.5px; text-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);">
-                      Verify Your Identity
+                      Confirm Your Activity
                     </h1>
                     <p style="margin: 0; color: rgba(255, 255, 255, 0.95); font-size: 17px; font-weight: 500; letter-spacing: 0.3px;">
                       The Serving Church
@@ -86,7 +86,7 @@
                 <tr>
                   <td style="background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%); border: 2px solid #fde68a; border-radius: 100px; padding: 8px 20px;">
                     <span style="color: #f59e0b; font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;">
-                      🔐 Verification Required
+                      📋 Confirmation Needed
                     </span>
                   </td>
                 </tr>
@@ -94,16 +94,16 @@
 
               <!-- Main Heading -->
               <h2 style="margin: 0 0 24px 0; color: #0f172a; font-size: 28px; font-weight: 800; line-height: 1.3; text-align: center; letter-spacing: -0.5px;">
-                Confirm It's Really You
+                Confirm Your Recent Activity
               </h2>
 
               <!-- Main Message -->
               <p style="margin: 0 0 20px 0; color: #475569; font-size: 17px; line-height: 1.7; text-align: center; font-weight: 400;">
-                You recently attempted to perform a sensitive account action. For your protection, we need to verify your identity before proceeding.
+                You recently started an account update in your member portal. To complete this change, please confirm using the button below.
               </p>
 
               <p style="margin: 0 0 36px 0; color: #64748b; font-size: 16px; line-height: 1.6; text-align: center;">
-                Click the button below to confirm this action and continue.
+                This helps us ensure the update was made by you.
               </p>
 
               <!-- CTA Button -->
@@ -114,7 +114,7 @@
                       <tr>
                         <td style="border-radius: 14px; background: linear-gradient(135deg, #f59e0b 0%, #eab308 100%); box-shadow: 0 10px 30px rgba(245, 158, 11, 0.35), 0 4px 10px rgba(234, 179, 8, 0.2);">
                           <a href="{{ .ConfirmationURL }}" style="display: inline-block; background: transparent; color: #ffffff; text-decoration: none; padding: 18px 48px; border-radius: 14px; font-size: 17px; font-weight: 700; letter-spacing: 0.3px; border: 2px solid rgba(255, 255, 255, 0.2);">
-                            ✓ Verify My Identity
+                            ✓ Confirm Activity
                           </a>
                         </td>
                       </tr>
@@ -152,11 +152,11 @@
                     </table>
 
                     <p style="margin: 0 0 12px 0; color: #b45309; font-size: 15px; line-height: 1.7;">
-                      This extra verification step helps protect your account from unauthorized access. We only ask for this when you're making important changes to your account.
+                      This extra step helps ensure that changes to your member account are made by you. We use this for important account updates.
                     </p>
 
                     <p style="margin: 0; color: #d97706; font-size: 14px; line-height: 1.6; font-style: italic;">
-                      🔒 This verification link expires in 15 minutes for security.
+                      💡 This confirmation link expires in 15 minutes.
                     </p>
                   </td>
                 </tr>
@@ -167,8 +167,8 @@
                 <tr>
                   <td style="background: #fef2f2; border: 2px solid #fecaca; border-radius: 12px; padding: 20px;">
                     <p style="margin: 0; color: #991b1b; font-size: 14px; line-height: 1.6; text-align: center;">
-                      <strong>⚠️ Didn't attempt this action?</strong><br/>
-                      If you didn't try to make any changes to your account, please contact us immediately at team@servingchurchdallas.com
+                      <strong>Didn't make this change?</strong><br/>
+                      If you didn't start this update, you can safely ignore this email or contact us at team@servingchurchdallas.com
                     </p>
                   </td>
                 </tr>
@@ -226,9 +226,9 @@
               <div style="margin: 24px 0; height: 1px; background: linear-gradient(90deg, transparent, #e2e8f0, transparent);"></div>
 
               <p style="margin: 0; color: #94a3b8; font-size: 12px; line-height: 1.7; text-align: center;">
-                This verification was requested for <strong style="color: #64748b;">{{ .Email }}</strong>
+                This confirmation was sent to <strong style="color: #64748b;">{{ .Email }}</strong>
                 <br/>
-                If you didn't make this request, please contact us right away.
+                If you didn't start this update, you can safely disregard this message.
               </p>
             </td>
           </tr>


### PR DESCRIPTION
Softened phishing-like language throughout:
- Changed "Verify Your Identity" to "Confirm Your Activity"
- Changed "Verification Required" to "Confirmation Needed"
- Changed "Confirm It's Really You" to "Confirm Your Recent Activity"
- Replaced "sensitive account action" with "account update"
- Removed urgent phrases like "immediately" and "right away"
- Changed "protect your account from unauthorized access" to normal business language
- Made security warnings less alarming
- Changed "Verify My Identity" button to "Confirm Activity"
- Overall more conversational, less urgent tone

This should improve email deliverability and reduce spam flags.