### PR TITLE
fix: escape apostrophes in JSX to resolve ESLint build errors

### DIFF
--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -66,7 +66,7 @@ export function NotificationSettings() {
         setSuccess("Push notifications disabled");
       } else {
         await subscribe();
-        setSuccess("Push notifications enabled! You'll receive notifications for new announcements.");
+        setSuccess("Push notifications enabled! You&apos;ll receive notifications for new announcements.");
       }
 
       setTimeout(() => setSuccess(null), 3000);
@@ -195,7 +195,7 @@ export function NotificationSettings() {
               <div className="p-3 bg-green-100 border border-green-300 rounded-md">
                 <p className="text-sm text-green-800 flex items-center gap-2">
                   <CheckCircle className="h-4 w-4" />
-                  You're subscribed to push notifications on this device
+                  You&apos;re subscribed to push notifications on this device
                 </p>
               </div>
             )}

--- a/src/components/announcements.tsx
+++ b/src/components/announcements.tsx
@@ -105,7 +105,7 @@ export function Announcements() {
             <h2 className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
               Latest Announcements
             </h2>
-            <p className="text-gray-600 mt-1">Stay updated with what's happening at The Serving Church</p>
+            <p className="text-gray-600 mt-1">Stay updated with what&apos;s happening at The Serving Church</p>
           </div>
           <Megaphone className="h-8 w-8 text-purple-600" />
         </div>


### PR DESCRIPTION
Fixed unescaped apostrophes that were causing Vercel build to fail:
- src/components/NotificationSettings.tsx: "You're" and "You'll"
- src/components/announcements.tsx: "what's"

All apostrophes now properly escaped as &apos; for JSX compliance.