### PR TITLE
fix: use 'new' status for all prayers to match database CHECK constraint

### DIFF
--- a/src/app/api/prayer-requests/route.ts
+++ b/src/app/api/prayer-requests/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
       email: email || null,
       request: prayerRequest,
       is_public: isPublic,
-      status: isPublic ? "public" : "new",
+      status: "new", // Use 'new' status for all prayers per database CHECK constraint
       prayer_count: 0,
     };
 


### PR DESCRIPTION
The database CHECK constraint only allows status values: 'new', 'praying', 'answered', 'ongoing', 'archived'. API was trying to insert 'public' status which violated the constraint and caused all prayer submissions to fail. Changed to use 'new' status for all prayers (both public and private).