### PR TITLE
feat: complete PWA setup with enhanced manifest and app shortcuts

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -77,9 +77,14 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.ico',
     shortcut: '/favicon.ico',
-    apple: '/apple-touch-icon.png',
+    apple: '/apple-icon.png',
   },
-  manifest: '/site.webmanifest',
+  manifest: '/manifest.json',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'default',
+    title: 'Serving',
+  },
   robots: {
     index: true,
     follow: true,

--- a/src/app/manifest.json
+++ b/src/app/manifest.json
@@ -1,21 +1,49 @@
 {
-  "name": "Serving Church",
+  "name": "The Serving Church",
   "short_name": "Serving",
+  "description": "Connect with The Serving Church community in Sunnyvale, TX. Access sermons, prayer requests, announcements, and events.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "theme_color": "#9e69e0",
+  "background_color": "#ffffff",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "/web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     }
   ],
-  "theme_color": "#9e69e0",
-  "background_color": "#ffffff",
-  "display": "standalone"
+  "categories": ["religion", "lifestyle"],
+  "shortcuts": [
+    {
+      "name": "Prayer Wall",
+      "short_name": "Prayers",
+      "description": "View and submit prayer requests",
+      "url": "/prayers",
+      "icons": [{ "src": "/web-app-manifest-192x192.png", "sizes": "192x192" }]
+    },
+    {
+      "name": "Events",
+      "short_name": "Events",
+      "description": "Church events and calendar",
+      "url": "/events",
+      "icons": [{ "src": "/web-app-manifest-192x192.png", "sizes": "192x192" }]
+    },
+    {
+      "name": "Donate",
+      "short_name": "Give",
+      "description": "Support our ministry",
+      "url": "/donate",
+      "icons": [{ "src": "/web-app-manifest-192x192.png", "sizes": "192x192" }]
+    }
+  ]
 }


### PR DESCRIPTION
- Enhanced manifest.json with full PWA metadata
- Added app shortcuts for Prayer Wall, Events, and Donate
- Updated layout.tsx to reference correct icon and manifest paths
- Added Apple Web App metadata for iOS support
- Changed icon purpose to 'maskable any' for better compatibility

Users can now install the church website as a PWA on mobile devices with:
- Home screen icon
- Standalone app experience
- Quick shortcuts to key pages
- Proper theme colors and branding