### PR TITLE
fix: add proper viewport configuration and PWA mobile responsive design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,3 +74,44 @@
       @apply bg-background text-foreground;
     }
   }
+
+  /* PWA Safe Area Support */
+  @supports (padding: max(0px)) {
+    body {
+      padding-left: env(safe-area-inset-left);
+      padding-right: env(safe-area-inset-right);
+      padding-bottom: env(safe-area-inset-bottom);
+    }
+
+    header {
+      padding-left: max(env(safe-area-inset-left), 1rem);
+      padding-right: max(env(safe-area-inset-right), 1rem);
+    }
+  }
+
+  /* Standalone PWA Mode Fixes */
+  @media all and (display-mode: standalone) {
+    body {
+      -webkit-user-select: none;
+      user-select: none;
+    }
+
+    /* Ensure proper viewport on iOS PWA */
+    html {
+      height: 100%;
+      width: 100%;
+      overflow-x: hidden;
+    }
+
+    body {
+      min-height: 100vh;
+      min-height: -webkit-fill-available;
+    }
+  }
+
+  /* Fix for iOS address bar */
+  @supports (-webkit-touch-callout: none) {
+    body {
+      min-height: -webkit-fill-available;
+    }
+  }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import React from 'react';
@@ -97,6 +97,18 @@ export const metadata: Metadata = {
     // yandex: 'your-yandex-verification-code',
     // bing: 'your-bing-verification-code',
   },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 5,
+  userScalable: true,
+  viewportFit: 'cover',
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#000000' },
+  ],
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Critical fixes for PWA standalone mode on mobile:
- Added viewport export with proper device-width settings
- Added viewportFit: 'cover' for notched devices
- Added safe area inset support for iOS notches
- Added standalone mode CSS fixes
- Added iOS-specific webkit fixes
- Prevents horizontal overflow in PWA mode

This fixes the issue where PWA showed desktop layout on mobile phones and ensures proper responsive behavior in standalone mode.