### PR TITLE
fix: force light mode to prevent dark mode styling issues

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -105,10 +105,7 @@ export const viewport: Viewport = {
   maximumScale: 5,
   userScalable: true,
   viewportFit: 'cover',
-  themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
-    { media: '(prefers-color-scheme: dark)', color: '#000000' },
-  ],
+  themeColor: '#ffffff', // Always use light theme color
 };
 
 export default function RootLayout({
@@ -142,8 +139,8 @@ export default function RootLayout({
         <NavComponent />
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="light"
+          forcedTheme="light"
           disableTransitionOnChange
         >
           <TooltipProvider>


### PR DESCRIPTION
Changes:
- Set ThemeProvider to forcedTheme='light' (was 'system')
- Removed enableSystem prop to prevent OS dark mode detection
- Changed viewport themeColor to fixed white (#ffffff)

This ensures the site always displays in light mode which looks perfect, instead of auto-detecting dark mode which has styling issues.